### PR TITLE
Fixed non-working Docker command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ There is a docker image at https://hub.docker.com/r/nilqed/fricas_jupyter/
 
 
     docker pull nilqed/fricas_jupyter
-    docker run -p 443:8888  -t -i nilqed/fricas_jupyter jupyter notebook
+    docker run -p 443:8888  -t -i nilqed/fricas_jupyter jupyter notebook --ip=*
     go to http://localhost:443
     New -> FriCAS
 


### PR DESCRIPTION
As the comment at https://hub.docker.com/r/nilqed/fricas_jupyter/
notes, the Docker command that's written produces an inaccessible
page.  Adding `--ip=*` to Jupyter's options fixes this.